### PR TITLE
Changed "Continue" to "Read more" (WCF 2.1)

### DIFF
--- a/language/en.xml
+++ b/language/en.xml
@@ -41,7 +41,7 @@
 		<item name="cms.news.commentResponse"><![CDATA[Response (Newscomment)]]></item>
 		<item name="cms.news.comment"><![CDATA[Newscomment]]></item>
 		<item name="cms.news.comments.count"><![CDATA[{#$news->comments} {if $news->comments == 1}Comment{else}Comments{/if}]]></item>
-		<item name="cms.news.read"><![CDATA[Continue]]></item>
+		<item name="cms.news.read"><![CDATA[Read more]]></item>
 		<item name="cms.news.ipAddress"><![CDATA[IP-Address]]></item>
 		<item name="cms.news.ipAddress.title"><![CDATA[IP-Address]]></item>
 		<item name="cms.news.ipAddress.news"><![CDATA[IP-Address of „{$news->username}“]]></item>


### PR DESCRIPTION
See: http://codequake.de/forum/index.php/Thread/2928-%E2%80%9ERead-more%E2%80%9C-anstelle-von-%E2%80%9EContinue%E2%80%9C/?postID=20814#post20814
